### PR TITLE
Don't show progress in non-interactive build due to an error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 target/
 !.mvn/wrapper/maven-wrapper.jar
 
+### Node cli and modules ###
+**/node
+**/node_modules
+
 ### STS ###
 .apt_generated
 .classpath

--- a/frontend/src/main/frontend/package.json
+++ b/frontend/src/main/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",
-    "build": "ng build",
+    "build": "ng build --no-progress",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
This eliminates an empty "[ERROR]" message that wasn't breaking Maven builds but would be caught by continuous integration builds and trigger a build failed message